### PR TITLE
feat: #4 add "queue" parameter to selector

### DIFF
--- a/examples/src/main/java/org/camunda/bpm/extension/example/reactor/TaskAssignListener.java
+++ b/examples/src/main/java/org/camunda/bpm/extension/example/reactor/TaskAssignListener.java
@@ -1,12 +1,14 @@
 package org.camunda.bpm.extension.example.reactor;
 
+import static org.camunda.bpm.extension.reactor.CamundaSelector.Queue.tasks;
+
 import org.camunda.bpm.engine.delegate.DelegateTask;
 import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.extension.reactor.CamundaSelector;
 import org.camunda.bpm.extension.reactor.listener.SubscriberTaskListener;
 import org.camunda.bpm.extension.reactor.plugin.ReactorProcessEnginePlugin;
 
-@CamundaSelector(type = "userTask", event = TaskListener.EVENTNAME_ASSIGNMENT)
+@CamundaSelector(queue = tasks, type = "userTask", event = TaskListener.EVENTNAME_ASSIGNMENT)
 public class TaskAssignListener extends SubscriberTaskListener {
 
   public TaskAssignListener() {

--- a/examples/src/main/java/org/camunda/bpm/extension/example/reactor/TaskCreateListener.java
+++ b/examples/src/main/java/org/camunda/bpm/extension/example/reactor/TaskCreateListener.java
@@ -1,5 +1,7 @@
 package org.camunda.bpm.extension.example.reactor;
 
+import static org.camunda.bpm.extension.reactor.CamundaSelector.Queue.tasks;
+
 import java.util.Arrays;
 
 import org.camunda.bpm.engine.delegate.DelegateTask;
@@ -9,9 +11,9 @@ import org.camunda.bpm.extension.reactor.listener.SubscriberTaskListener;
 
 import reactor.bus.EventBus;
 
-@CamundaSelector(type = "userTask", event = TaskListener.EVENTNAME_CREATE)
+@CamundaSelector(queue = tasks, type = "userTask", event = TaskListener.EVENTNAME_CREATE)
 public class TaskCreateListener extends SubscriberTaskListener {
-  
+
   public TaskCreateListener(EventBus eventBus) {
     register(eventBus);
   }
@@ -19,10 +21,10 @@ public class TaskCreateListener extends SubscriberTaskListener {
   @Override
   public void notify(DelegateTask delegateTask) {
     delegateTask.setDueDate(ProcessA.DUE_DATE);
-    
+
     delegateTask.addCandidateGroup(ProcessA.GROUP_1);
     delegateTask.addCandidateGroups(Arrays.asList(ProcessA.GROUP_2,ProcessA.GROUP_3));
 
-    //delegateTask.setAssignee("me");
+    delegateTask.setAssignee("me");
   }
 }

--- a/examples/src/test/java/org/camunda/bpm/extension/example/reactor/ProcessATest.java
+++ b/examples/src/test/java/org/camunda/bpm/extension/example/reactor/ProcessATest.java
@@ -1,22 +1,15 @@
 package org.camunda.bpm.extension.example.reactor;
 
-import org.camunda.bpm.engine.delegate.DelegateTask;
-import org.camunda.bpm.engine.delegate.TaskListener;
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineAssertions.assertThat;
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
+
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
-import org.camunda.bpm.engine.test.assertions.ProcessEngineTests;
-import org.camunda.bpm.engine.test.mock.Mocks;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.bridge.SLF4JBridgeHandler;
-
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.runtimeService;
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.taskService;
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.taskQuery;
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineAssertions.assertThat;
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.task;
 
 public class ProcessATest {
   static {
@@ -37,21 +30,21 @@ public class ProcessATest {
 
     assertThat(processInstance).isWaitingAt("task_a");
     assertThat(task()).hasDueDate(ProcessA.DUE_DATE);
-    
-    
+
+
     Task t = taskService().createTaskQuery().singleResult();
     assertThat(taskQuery().taskId(t.getId()).taskCandidateGroup(ProcessA.GROUP_1).includeAssignedTasks().singleResult()).isNotNull();
     assertThat(taskQuery().taskId(t.getId()).taskCandidateGroup(ProcessA.GROUP_2).includeAssignedTasks().singleResult()).isNotNull();
     assertThat(taskQuery().taskId(t.getId()).taskCandidateGroup(ProcessA.GROUP_3).includeAssignedTasks().singleResult()).isNotNull();
-    
-    
+
+
 
     //assertThat(task()).hasCandidateGroup(ProcessA.GROUP_1);
     //assertThat(task()).hasCandidateGroup(ProcessA.GROUP_2);
     //assertThat(task()).hasCandidateGroup(ProcessA.GROUP_2);
-    //assertThat(task()).isAssignedTo("me");
+    assertThat(task()).isAssignedTo("me");
 
-    
+
   }
 }
 

--- a/extension/core/src/main/java/org/camunda/bpm/extension/reactor/CamundaReactor.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/reactor/CamundaReactor.java
@@ -19,7 +19,7 @@ import reactor.bus.selector.Selectors;
 
 public final class CamundaReactor {
 
-  public static final String CAMUNDA_TOPIC = "/camunda/{type}/{process}/{element}/{event}";
+  public static final String CAMUNDA_TOPIC = "/camunda/{queue}/{type}/{process}/{element}/{event}";
 
   public static class SubscribeTo {
     private final EventBus eventBus;

--- a/extension/core/src/main/java/org/camunda/bpm/extension/reactor/CamundaSelector.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/reactor/CamundaSelector.java
@@ -9,9 +9,17 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface CamundaSelector {
 
-  public String type() default "";
-  public String element() default "";
-  public String process() default "";
-  public String event() default "";
+  Queue queue() default Queue.none;
+  String type() default "";
+  String element() default "";
+  String process() default "";
+  String event() default "";
+
+  enum Queue {
+    tasks,
+    processExecutions,
+    caseExecutions,
+    none
+  }
 
 }

--- a/extension/core/src/main/java/org/camunda/bpm/extension/reactor/SelectorBuilder.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/reactor/SelectorBuilder.java
@@ -3,6 +3,9 @@ package org.camunda.bpm.extension.reactor;
 
 import static org.camunda.bpm.extension.reactor.CamundaReactor.caseDefintionKey;
 import static org.camunda.bpm.extension.reactor.CamundaReactor.processDefintionKey;
+import static org.camunda.bpm.extension.reactor.CamundaSelector.Queue.caseExecutions;
+import static org.camunda.bpm.extension.reactor.CamundaSelector.Queue.processExecutions;
+import static org.camunda.bpm.extension.reactor.CamundaSelector.Queue.tasks;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +26,7 @@ public class SelectorBuilder {
 
   public static SelectorBuilder selector(final DelegateTask delegateTask) {
     return selector()
+      .queue(tasks)
       .type(extractTypeName(delegateTask))
       .process(processDefintionKey(delegateTask.getProcessDefinitionId()))
       .element(delegateTask.getTaskDefinitionKey())
@@ -36,6 +40,7 @@ public class SelectorBuilder {
       : delegateExecution.getCurrentActivityId();
 
     return selector()
+      .queue(processExecutions)
       .type(typeName)
       .process(processDefintionKey(delegateExecution.getProcessDefinitionId()))
       .element(element)
@@ -47,6 +52,7 @@ public class SelectorBuilder {
     String element = delegateCaseExecution.getActivityId();
 
     return selector()
+      .queue(caseExecutions)
       .type(typeName)
       .caseDefinitionKey(caseDefintionKey(delegateCaseExecution.getCaseDefinitionId()))
       .element(element)
@@ -70,6 +76,7 @@ public class SelectorBuilder {
 
   public static SelectorBuilder selector(final CamundaSelector annotation) {
     return selector()
+      .queue(annotation.queue())
       .type(annotation.type())
       .process(annotation.process())
       .element(annotation.element())
@@ -80,6 +87,12 @@ public class SelectorBuilder {
 
   private SelectorBuilder() {
     // noop
+  }
+
+  public SelectorBuilder queue(CamundaSelector.Queue queue) {
+    values.put("{queue}", queue==null ? "" : queue.name());
+
+    return this;
   }
 
   public SelectorBuilder process(String process) {

--- a/extension/core/src/test/java/org/camunda/bpm/extension/reactor/CamundaReactorTest.java
+++ b/extension/core/src/test/java/org/camunda/bpm/extension/reactor/CamundaReactorTest.java
@@ -25,32 +25,32 @@ public class CamundaReactorTest {
 
   @Test
   public void camunda_topic() {
-    assertThat(CamundaReactor.CAMUNDA_TOPIC).isEqualTo("/camunda/{type}/{process}/{element}/{event}");
+    assertThat(CamundaReactor.CAMUNDA_TOPIC).isEqualTo("/camunda/{queue}/{type}/{process}/{element}/{event}");
   }
 
   @Test
   public void creates_topic_for_process_element_and_event() {
-    assertThat(CamundaReactor.key("process", "task", "create")).isEqualTo("/camunda/{type}/process/task/create");
+    assertThat(CamundaReactor.key("process", "task", "create")).isEqualTo("/camunda/{queue}/{type}/process/task/create");
   }
 
   @Test
   public void creates_general_topic_for_null_values() {
-    assertThat(CamundaReactor.key(null, null, null)).isEqualTo("/camunda/{type}/{process}/{element}/{event}");
+    assertThat(CamundaReactor.key(null, null, null)).isEqualTo("/camunda/{queue}/{type}/{process}/{element}/{event}");
   }
 
   @Test
   public void creates_topic_for_element() {
-    assertThat(CamundaReactor.key(null, "task", null)).isEqualTo("/camunda/{type}/{process}/task/{event}");
+    assertThat(CamundaReactor.key(null, "task", null)).isEqualTo("/camunda/{queue}/{type}/{process}/task/{event}");
   }
 
   @Test
   public void creates_topic_for_process() {
-    assertThat(CamundaReactor.key("foo", null, null)).isEqualTo("/camunda/{type}/foo/{element}/{event}");
+    assertThat(CamundaReactor.key("foo", null, null)).isEqualTo("/camunda/{queue}/{type}/foo/{element}/{event}");
   }
 
   @Test
   public void creates_topic_for_event() {
-    assertThat(CamundaReactor.key(null, null, "bar")).isEqualTo("/camunda/{type}/{process}/{element}/bar");
+    assertThat(CamundaReactor.key(null, null, "bar")).isEqualTo("/camunda/{queue}/{type}/{process}/{element}/bar");
   }
 
   @Test

--- a/extension/core/src/test/java/org/camunda/bpm/extension/reactor/CamundaSelectorTest.java
+++ b/extension/core/src/test/java/org/camunda/bpm/extension/reactor/CamundaSelectorTest.java
@@ -1,20 +1,21 @@
 package org.camunda.bpm.extension.reactor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.camunda.bpm.extension.reactor.CamundaSelector.Queue.tasks;
+
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.extension.reactor.listener.SubscriberExecutionListener;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class CamundaSelectorTest {
 
-  @CamundaSelector(element = "e", event = "ev", process = "p", type = "t")
+  @CamundaSelector(queue = tasks, element = "e", event = "ev", process = "p", type = "t")
   public static  class Full extends SubscriberExecutionListener {
 
     @Override
     public void notify(DelegateExecution execution) throws Exception {
       // TODO Auto-generated method stub
-      
+
     }
 
   }
@@ -25,19 +26,19 @@ public class CamundaSelectorTest {
     @Override
     public void notify(DelegateExecution execution) throws Exception {
       // TODO Auto-generated method stub
-      
+
     }
 
   }
 
   @Test
   public void full_selector_path() {
-    assertThat(SelectorBuilder.selector(new Full() ).key()).isEqualTo("/camunda/t/p/e/ev");
+    assertThat(SelectorBuilder.selector(new Full() ).key()).isEqualTo("/camunda/tasks/t/p/e/ev");
   }
 
   @Test
   public void empty_selector_path() {
-    assertThat(SelectorBuilder.selector(new None()).key()).isEqualTo("/camunda/{type}/{process}/{element}/{event}");
+    assertThat(SelectorBuilder.selector(new None()).key()).isEqualTo("/camunda/none/{type}/{process}/{element}/{event}");
   }
 
 }

--- a/extension/core/src/test/java/org/camunda/bpm/extension/reactor/SelectorBuilderTest.java
+++ b/extension/core/src/test/java/org/camunda/bpm/extension/reactor/SelectorBuilderTest.java
@@ -18,18 +18,18 @@ public class SelectorBuilderTest {
   @Parameters(name = "{index}: builder=''{0}'', expected=''{1}''")
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-      {selector(), "/camunda/{type}/{process}/{element}/{event}"},
-      {selector().process("foo"), "/camunda/{type}/foo/{element}/{event}"},
-      {selector().process("foo").element("bar"), "/camunda/{type}/foo/bar/{event}"},
-      {selector().process("foo").element("bar").event("create"), "/camunda/{type}/foo/bar/create"},
-      {selector().element("bar").event("create"), "/camunda/{type}/{process}/bar/create"},
-      {selector().element("bar"), "/camunda/{type}/{process}/bar/{event}"},
-      {selector().event("create"), "/camunda/{type}/{process}/{element}/create"},
-      {selector().type("type"), "/camunda/type/{process}/{element}/{event}"},
-      {selector().type(""), "/camunda/{type}/{process}/{element}/{event}"},
-      {selector().caseDefinitionKey("foo"), "/camunda/{type}/foo/{element}/{event}"},
-      {selector().caseDefinitionKey("foo").element("bar"), "/camunda/{type}/foo/bar/{event}"},
-      {selector().caseDefinitionKey("foo").element("bar").event("create"), "/camunda/{type}/foo/bar/create"},
+      {selector(), "/camunda/{queue}/{type}/{process}/{element}/{event}"},
+      {selector().process("foo"), "/camunda/{queue}/{type}/foo/{element}/{event}"},
+      {selector().process("foo").element("bar"), "/camunda/{queue}/{type}/foo/bar/{event}"},
+      {selector().process("foo").element("bar").event("create"), "/camunda/{queue}/{type}/foo/bar/create"},
+      {selector().element("bar").event("create"), "/camunda/{queue}/{type}/{process}/bar/create"},
+      {selector().element("bar"), "/camunda/{queue}/{type}/{process}/bar/{event}"},
+      {selector().event("create"), "/camunda/{queue}/{type}/{process}/{element}/create"},
+      {selector().type("type"), "/camunda/{queue}/type/{process}/{element}/{event}"},
+      {selector().type(""), "/camunda/{queue}/{type}/{process}/{element}/{event}"},
+      {selector().caseDefinitionKey("foo"), "/camunda/{queue}/{type}/foo/{element}/{event}"},
+      {selector().caseDefinitionKey("foo").element("bar"), "/camunda/{queue}/{type}/foo/bar/{event}"},
+      {selector().caseDefinitionKey("foo").element("bar").event("create"), "/camunda/{queue}/{type}/foo/bar/create"},
     });
   }
 


### PR DESCRIPTION
Supports separation of CMMN, BPMN and task events.
The topic name is enhanced by an additionaly parameter named "queue" (I had no better idea than that)
