### PR TITLE
Bugfix: if a @CamundaSelector is used with process element  and uuid

### DIFF
--- a/examples/bpmn-execution-listener/pom.xml
+++ b/examples/bpmn-execution-listener/pom.xml
@@ -34,6 +34,12 @@
       <artifactId>camunda-bpm-reactor-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>com.h2database</groupId>

--- a/examples/bpmn-execution-listener/src/main/java/org/camunda/bpm/extension/example/reactor/KpiExecutionListener.java
+++ b/examples/bpmn-execution-listener/src/main/java/org/camunda/bpm/extension/example/reactor/KpiExecutionListener.java
@@ -16,7 +16,7 @@ import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.ExecutionListener;
 import org.camunda.bpm.extension.reactor.bus.CamundaSelector;
 
-@CamundaSelector(type = "intermediateThrowEvent", event = ExecutionListener.EVENTNAME_START)
+@CamundaSelector(type = "intermediateThrowEvent", event = ExecutionListener.EVENTNAME_START, process = "process")
 public class KpiExecutionListener implements ExecutionListener {
 
   private static final String NAME_PREFIX = "KPI:";

--- a/examples/bpmn-execution-listener/src/main/java/org/camunda/bpm/extension/example/reactor/Setup.java
+++ b/examples/bpmn-execution-listener/src/main/java/org/camunda/bpm/extension/example/reactor/Setup.java
@@ -3,6 +3,7 @@ package org.camunda.bpm.extension.example.reactor;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.persistence.StrongUuidGenerator;
 import org.camunda.bpm.extension.reactor.CamundaReactor;
 import org.camunda.bpm.extension.reactor.bus.CamundaEventBus;
 
@@ -14,6 +15,7 @@ public class Setup {
       this.getProcessEnginePlugins().add(CamundaReactor.plugin());
       this.jobExecutorActivate = false;
       this.isDbMetricsReporterActivate = false;
+      this.idGenerator = new StrongUuidGenerator(); // should be used for production
     }
   };
 

--- a/extension/core/src/main/java/org/camunda/bpm/extension/reactor/bus/SelectorBuilder.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/reactor/bus/SelectorBuilder.java
@@ -185,7 +185,7 @@ public class SelectorBuilder {
    * @return process or case definition key
    */
   static String defintionKey(String definitionId) {
-    return definitionId.replaceAll("(\\w+):\\d+:\\d+", "$1");
+    return definitionId.replaceAll("(\\w+):\\d+:[\\w-]+", "$1");
   }
 
   static String defintionKey(DelegateTask task) {

--- a/extension/core/src/test/java/org/camunda/bpm/extension/reactor/bus/SelectorBuilderTest.java
+++ b/extension/core/src/test/java/org/camunda/bpm/extension/reactor/bus/SelectorBuilderTest.java
@@ -132,6 +132,11 @@ public class SelectorBuilderTest {
     public void retrieve_caseDefinitionKey_from_definitionId() {
       assertThat(caseDefintionKey("case_a:1:3")).isEqualTo("case_a");
     }
+
+    @Test
+    public void retrieve_processDefinitionKey_from_definitionIdUUID() {
+      assertThat(SelectorBuilder.defintionKey("process_a:1:b8315d43-e0b3-11e7-bccb-54ee75c51662")).isEqualTo("process_a");
+    }
   }
 
   public static class NotificationKey {


### PR DESCRIPTION
if a @CamundaSelector is used with process element  and the StrongUuidGenerator (which should be used for production) the selection fails because defintionKey expects a number after the second colon.


example:
@CamundaSelector(type = "intermediateThrowEvent", event = ExecutionListener.EVENTNAME_START, **process = "process"**)

and in Setup:
...
      this.idGenerator = new StrongUuidGenerator();
...

will fail without this patch.