### PR TITLE
Update pom.xml fix issue #100

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.21.0</version>
         <configuration>
           <runOrder>${surefire.runOrder}</runOrder>
         </configuration>


### PR DESCRIPTION
Updating maven-surefire version from 2.20.1 to 2.21.0.
Reason: maven-surefire 2.20.1 throws NPE when running tests on JDK 10 or higher.
[Official solved issue](https://bugzilla.redhat.com/show_bug.cgi?id=1572708)
Project issue #100

Compiling project with maven-surefire 2.20.1 log:

> Reactor Summary for camunda-bpm-reactor-root 2.11.0-SNAPSHOT:
> [INFO] 
> [INFO] camunda-bpm-reactor-root ........................... SUCCESS [  0.265 s]
> [INFO] camunda-bpm-reactor-extension-root ................. SUCCESS [  0.014 s]
> [INFO] camunda-bpm-reactor-eventbus ....................... FAILURE [  7.985 s]
> [INFO] camunda-bpm-reactor-core ........................... SKIPPED
> [INFO] camunda-bpm-reactor-spring ......................... SKIPPED
> [INFO] camunda-bpm-reactor-spring-starter ................. SKIPPED
> [INFO] camunda-bpm-reactor-example-root ................... SKIPPED
> [INFO] camunda-bpm-reactor-example-bpmn-task-listener ..... SKIPPED
> [INFO] camunda-bpm-reactor-example-cmmn-task-listener ..... SKIPPED
> [INFO] camunda-bpm-reactor-example-bpmn-execution-listener  SKIPPED
> [INFO] camunda-bpm-reactor-example-spring-plugin .......... SKIPPED
> [INFO] camunda-bpm-reactor-example-spring-starter ......... SKIPPED
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD FAILURE
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  9.877 s
> [INFO] Finished at: 2020-12-04T12:27:30-03:00
> [INFO] ------------------------------------------------------------------------
> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test (default-test) on project camunda-bpm-reactor-eventbus: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test failed. NullPointerException -> [Help 1]
> [ERROR] 
> [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
> [ERROR] Re-run Maven using the -X switch to enable full debug logging.
> [ERROR] 
> [ERROR] For more information about the errors and possible solutions, please read the following articles:
> [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
> [ERROR] 
> [ERROR] After correcting the problems, you can resume the build with the command
> [ERROR]   mvn <args> -rf :camunda-bpm-reactor-eventbus

 Compiling project with maven-surefire 2.21.0 log:
> [INFO] Reactor Summary for camunda-bpm-reactor-root 2.11.0-SNAPSHOT:
> [INFO] 
> [INFO] camunda-bpm-reactor-root ........................... SUCCESS [  0.172 s]
> [INFO] camunda-bpm-reactor-extension-root ................. SUCCESS [  0.004 s]
> [INFO] camunda-bpm-reactor-eventbus ....................... SUCCESS [  0.490 s]
> [INFO] camunda-bpm-reactor-core ........................... SUCCESS [  0.162 s]
> [INFO] camunda-bpm-reactor-spring ......................... SUCCESS [  0.072 s]
> [INFO] camunda-bpm-reactor-spring-starter ................. SUCCESS [  0.045 s]
> [INFO] camunda-bpm-reactor-example-root ................... SUCCESS [  0.006 s]
> [INFO] camunda-bpm-reactor-example-bpmn-task-listener ..... SUCCESS [  0.069 s]
> [INFO] camunda-bpm-reactor-example-cmmn-task-listener ..... SUCCESS [  0.085 s]
> [INFO] camunda-bpm-reactor-example-bpmn-execution-listener  SUCCESS [  0.090 s]
> [INFO] camunda-bpm-reactor-example-spring-plugin .......... SUCCESS [  0.077 s]
> [INFO] camunda-bpm-reactor-example-spring-starter ......... SUCCESS [  0.066 s]
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD SUCCESS
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  4.158 s
> [INFO] Finished at: 2020-12-04T11:17:57-03:00
> [INFO] ------------------------------------------------------------------------